### PR TITLE
Add test command to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Test
+        run: pnpm run test
+
       - name: Build
         run: pnpm run build


### PR DESCRIPTION
The CI workflow in `.github/workflows/ci.yml` was updated to include a new test step.

*   A `Test` step was added, configured to run `pnpm run test`.
*   This step is positioned after the existing `Lint` step and before the `Build` step.

This modification integrates automated testing into the continuous integration pipeline. The `pnpm run test` command will now execute as part of the CI process, ensuring that tests pass before the project proceeds to the build stage. This helps in validating code correctness early and maintaining overall code quality. The workflow continues to trigger on pushes and pull requests to the master branch, now with integrated test validation.