### PR TITLE
Add format button for code editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@codemirror/commands": "^6.8.1",
     "@codemirror/state": "^6.5.2",
     "@codemirror/view": "^6.37.2",
+    "@cospaia/prettier-plugin-clojure": "^0.0.2",
     "@logseq/libs": "^0.0.17",
     "@nextjournal/clojure-mode": "^0.3.3",
     "codemirror": "^6.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@codemirror/view':
         specifier: ^6.37.2
         version: 6.37.2
+      '@cospaia/prettier-plugin-clojure':
+        specifier: ^0.0.2
+        version: 0.0.2
       '@logseq/libs':
         specifier: ^0.0.17
         version: 0.0.17
@@ -149,6 +152,9 @@ packages:
 
   '@codemirror/view@6.37.2':
     resolution: {integrity: sha512-XD3LdgQpxQs5jhOOZ2HRVT+Rj59O4Suc7g2ULvZ+Yi8eCkickrkZ5JFuoDhs2ST1mNI5zSsNYgR3NGa4OUrbnw==}
+
+  '@cospaia/prettier-plugin-clojure@0.0.2':
+    resolution: {integrity: sha512-5ZgNOdiiIHbcBLvJhonCGoHFfuLlfsA+CjohiZGVuyD2XMVi35YFr7vZ6eSHeWjFAUsKRFbcOqtoXsV1Wk7zXA==}
 
   '@csstools/color-helpers@5.0.2':
     resolution: {integrity: sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==}
@@ -2410,6 +2416,8 @@ snapshots:
       crelt: 1.0.6
       style-mod: 4.1.2
       w3c-keyname: 2.2.8
+
+  '@cospaia/prettier-plugin-clojure@0.0.2': {}
 
   '@csstools/color-helpers@5.0.2': {}
 

--- a/src/components/CodeMirrorEditor.test.tsx
+++ b/src/components/CodeMirrorEditor.test.tsx
@@ -17,6 +17,29 @@ describe('CodeMirrorEditor', () => {
       expect(container.querySelector('.cm-editor')).toBeTruthy()
     })
   })
+
+  it('renders format button', () => {
+    render(<CodeMirrorEditor value="test code" />)
+
+    // Should always show the Format button
+    expect(screen.getByRole('button', { name: /format/i })).toBeInTheDocument()
+  })
+
+  it('renders with onRun prop', () => {
+    const onRun = () => {}
+    render(<CodeMirrorEditor value="test code" onRun={onRun} />)
+
+    // Should show the Run button when onRun is provided
+    expect(screen.getByRole('button', { name: /run/i })).toBeInTheDocument()
+  })
+
+  it('renders undo and redo buttons', () => {
+    render(<CodeMirrorEditor value="test code" />)
+
+    // Should always show Undo and Redo buttons
+    expect(screen.getByRole('button', { name: /undo/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /redo/i })).toBeInTheDocument()
+  })
 })
 
 // Add test to ensure the editor is not remounted (loses focus) on value updates.

--- a/src/components/CodeMirrorEditor.test.tsx
+++ b/src/components/CodeMirrorEditor.test.tsx
@@ -1,12 +1,25 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { render, waitFor } from '@testing-library/react'
 import { fireEvent, screen } from '@testing-library/react'
 import { useState } from 'react'
 
 import CodeMirrorEditor from './CodeMirrorEditor'
 
+// Mock prettier
+vi.mock('prettier', () => ({
+  default: {
+    format: vi.fn(),
+  },
+}))
+
+import prettier from 'prettier'
+
 // A simple smoke test to verify the editor can mount without runtime errors.
 describe('CodeMirrorEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('mounts a CodeMirror instance', async () => {
     const { container } = render(
       <CodeMirrorEditor value={'(println "hello")'} />,
@@ -39,6 +52,84 @@ describe('CodeMirrorEditor', () => {
     // Should always show Undo and Redo buttons
     expect(screen.getByRole('button', { name: /undo/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /redo/i })).toBeInTheDocument()
+  })
+
+  it('formats code when format button is clicked', async () => {
+    const mockFormat = vi.mocked(prettier.format)
+    const unformattedCode = '(defn foo[x y](+ x y))'
+    const formattedCode = '(defn foo [x y]\n  (+ x y))'
+
+    // Mock prettier.format to return formatted code
+    mockFormat.mockResolvedValue(formattedCode)
+
+    const onChangeMock = vi.fn()
+
+    render(<CodeMirrorEditor value={unformattedCode} onChange={onChangeMock} />)
+
+    // Wait for editor to mount
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /format/i }),
+      ).toBeInTheDocument()
+    })
+
+    // Click the format button
+    const formatButton = screen.getByRole('button', { name: /format/i })
+    fireEvent.click(formatButton)
+
+    // Wait for async formatting to complete
+    await waitFor(() => {
+      // Verify prettier.format was called with correct arguments
+      expect(mockFormat).toHaveBeenCalledWith(unformattedCode, {
+        parser: 'clojure',
+        plugins: ['@cospaia/prettier-plugin-clojure'],
+      })
+
+      // Verify onChange was called with formatted code
+      expect(onChangeMock).toHaveBeenCalledWith(formattedCode)
+    })
+  })
+
+  it('handles formatting errors gracefully', async () => {
+    const mockFormat = vi.mocked(prettier.format)
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Mock prettier.format to throw an error
+    mockFormat.mockRejectedValue(new Error('Invalid Clojure syntax'))
+
+    const onChangeMock = vi.fn()
+
+    render(
+      <CodeMirrorEditor value="(defn incomplete" onChange={onChangeMock} />,
+    )
+
+    // Wait for editor to mount
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /format/i }),
+      ).toBeInTheDocument()
+    })
+
+    // Click the format button
+    const formatButton = screen.getByRole('button', { name: /format/i })
+    fireEvent.click(formatButton)
+
+    // Wait for error handling
+    await waitFor(() => {
+      // Verify prettier.format was called
+      expect(mockFormat).toHaveBeenCalled()
+
+      // Verify error was logged
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Failed to format code:',
+        expect.any(Error),
+      )
+
+      // Verify onChange was NOT called since formatting failed
+      expect(onChangeMock).not.toHaveBeenCalled()
+    })
+
+    consoleSpy.mockRestore()
   })
 })
 

--- a/src/components/CodeMirrorEditor.tsx
+++ b/src/components/CodeMirrorEditor.tsx
@@ -77,7 +77,6 @@ export default function CodeMirrorEditor({
   }
 
   // Mount the EditorView once. Callback refs used so we don't depend on onChange/onRun.
-
   useEffect(() => {
     if (!containerRef.current) return
     if (viewRef.current) return // already mounted
@@ -120,7 +119,7 @@ export default function CodeMirrorEditor({
       viewRef.current?.destroy()
       viewRef.current = null
     }
-  }, [])
+  }, []) // Intentionally empty - we only want to mount once
 
   // Keep external value in sync when it changes (rare)
   useEffect(() => {

--- a/src/components/CodeMirrorEditor.tsx
+++ b/src/components/CodeMirrorEditor.tsx
@@ -10,6 +10,8 @@ import {
   complete_keymap,
   language_support,
 } from '@nextjournal/clojure-mode'
+// Import prettier for formatting
+import prettier from 'prettier'
 
 export interface CodeMirrorEditorProps {
   /** Current editor value */
@@ -46,6 +48,33 @@ export default function CodeMirrorEditor({
   useEffect(() => {
     onRunRef.current = onRun
   }, [onRun])
+
+  // Format the current code using prettier with Clojure plugin
+  const formatCode = async () => {
+    const view = viewRef.current
+    if (!view) return
+
+    try {
+      const currentCode = view.state.doc.toString()
+      const formattedCode = await prettier.format(currentCode, {
+        parser: 'clojure',
+        plugins: ['@cospaia/prettier-plugin-clojure'],
+      })
+
+      // Apply the formatted code to the editor
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: formattedCode },
+      })
+
+      // Notify parent component of the change
+      if (onChangeRef.current) {
+        onChangeRef.current(formattedCode)
+      }
+    } catch (error) {
+      console.error('Failed to format code:', error)
+      // Could show user-friendly error message here
+    }
+  }
 
   // Mount the EditorView once. Callback refs used so we don't depend on onChange/onRun.
 
@@ -124,6 +153,16 @@ export default function CodeMirrorEditor({
             ▶ Run
           </button>
         )}
+
+        {/* Format Button */}
+        <button
+          type="button"
+          onClick={formatCode}
+          title="Format code using prettier"
+          style={{ cursor: 'pointer' }}
+        >
+          ✨ Format
+        </button>
 
         {/* Undo / Redo use CodeMirror commands */}
         <button


### PR DESCRIPTION
A "Format" button was added to the `CodeMirrorEditor.tsx` component, enabling code formatting within the editor.

*   The `@cospaia/prettier-plugin-clojure` dependency was added to `package.json` and installed via pnpm to provide Clojure-specific formatting capabilities.
*   An asynchronous `formatCode` function was implemented in `CodeMirrorEditor.tsx`. This function uses `prettier` with the Clojure plugin to format the current editor content, then dispatches the formatted code back to the editor view and notifies the parent component via the `onChange` callback.
*   The "Format" button was integrated into the existing toolbar in `CodeMirrorEditor.tsx`, with an `onClick` handler calling the `formatCode` function.
*   Tests in `src/components/CodeMirrorEditor.test.tsx` were updated to include checks for the new "Format" button's rendering and functionality.
*   The `TODO.md` file was updated to reflect the completion of the "format" button task.