### PR TITLE
Add close button for app shutdown

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import App from './App'
+
+// Mock the utils/queryRunner module since we're testing UI behavior
+vi.mock('./utils/queryRunner', () => ({
+  runQuery: vi.fn().mockResolvedValue('mocked result'),
+}))
+
+describe('App', () => {
+  beforeEach(() => {
+    // Clear any existing global logseq
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any).logseq
+    // Mock window.confirm and window.close
+    vi.spyOn(window, 'confirm').mockImplementation(() => false)
+    vi.spyOn(window, 'close').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders the main heading and close button', () => {
+    render(<App />)
+
+    expect(
+      screen.getByText('Advanced Query Editor (Sandbox)'),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '✕' })).toBeInTheDocument()
+    // Use getAllByRole to get all run buttons and check that at least one exists
+    const runButtons = screen.getAllByRole('button', { name: /run/i })
+    expect(runButtons.length).toBeGreaterThan(0)
+  })
+
+  it('calls logseq.hideMainUI when close button is clicked in Logseq environment', () => {
+    const mockHideMainUI = vi.fn()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(globalThis as any).logseq = {
+      hideMainUI: mockHideMainUI,
+    }
+
+    render(<App />)
+
+    const closeButton = screen.getByRole('button', { name: '✕' })
+    fireEvent.click(closeButton)
+
+    expect(mockHideMainUI).toHaveBeenCalledOnce()
+    expect(window.confirm).not.toHaveBeenCalled()
+  })
+
+  it('shows confirmation dialog in standalone environment when close button is clicked', () => {
+    // No logseq object - standalone environment
+    render(<App />)
+
+    const closeButton = screen.getByRole('button', { name: '✕' })
+    fireEvent.click(closeButton)
+
+    expect(window.confirm).toHaveBeenCalledWith(
+      'Close the Advanced Query Editor?',
+    )
+    expect(window.close).not.toHaveBeenCalled() // because we mocked confirm to return false
+  })
+
+  it('calls window.close when user confirms in standalone environment', () => {
+    vi.spyOn(window, 'confirm').mockImplementation(() => true)
+
+    render(<App />)
+
+    const closeButton = screen.getByRole('button', { name: '✕' })
+    fireEvent.click(closeButton)
+
+    expect(window.confirm).toHaveBeenCalledWith(
+      'Close the Advanced Query Editor?',
+    )
+    expect(window.close).toHaveBeenCalledOnce()
+  })
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,9 +26,52 @@ function App() {
     }
   }, [code])
 
+  const handleClose = useCallback(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const logseq = (globalThis as any).logseq
+
+    if (logseq?.hideMainUI) {
+      // Running inside Logseq - hide the plugin UI to return to main Logseq interface
+      logseq.hideMainUI()
+    } else {
+      // Running standalone - show message or close window if possible
+      const shouldClose = window.confirm('Close the Advanced Query Editor?')
+      if (shouldClose) {
+        window.close()
+      }
+    }
+  }, [])
+
   return (
     <main style={{ maxWidth: 800, margin: '2rem auto' }}>
-      <h1 style={{ textAlign: 'center' }}>Advanced Query Editor (Sandbox)</h1>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: '1rem',
+        }}
+      >
+        <h1 style={{ textAlign: 'center', margin: 0, flex: 1 }}>
+          Advanced Query Editor (Sandbox)
+        </h1>
+        <button
+          type="button"
+          onClick={handleClose}
+          style={{
+            background: 'none',
+            border: '1px solid #ccc',
+            borderRadius: '4px',
+            padding: '0.5rem',
+            cursor: 'pointer',
+            fontSize: '16px',
+            lineHeight: 1,
+          }}
+          title="Close and return to Logseq"
+        >
+          ✕
+        </button>
+      </div>
       <CodeMirrorEditor value={code} onChange={setCode} onRun={execute} />
 
       <div style={{ marginTop: '1rem', display: 'flex', gap: '0.5rem' }}>

--- a/src/types/edn-data.d.ts
+++ b/src/types/edn-data.d.ts
@@ -1,0 +1,9 @@
+declare module 'edn-data' {
+  interface ParseOptions {
+    mapAs?: 'object' | 'map'
+    keywordAs?: 'string' | 'keyword'
+  }
+
+  /** Parse an EDN string and return the corresponding JavaScript value */
+  export function parseEDNString(edn: string, options?: ParseOptions): unknown
+}


### PR DESCRIPTION
A close button was added to the application's header in `src/App.tsx`.

*   The button's `onClick` handler, `handleClose`, implements conditional logic:
    *   If `logseq.hideMainUI()` is available (indicating a Logseq environment), it is called to return to the main Logseq interface.
    *   Otherwise (standalone mode), a `window.confirm` dialog prompts the user, and `window.close()` is called if confirmed.
*   Comprehensive tests were added in `src/App.test.tsx` to validate the close button's behavior in both Logseq and standalone environments, including mocking `logseq.hideMainUI`, `window.confirm`, and `window.close`.
*   A type declaration file, `src/types/edn-data.d.ts`, was created for the `edn-data` module to resolve build errors and improve type safety.
*   Test selectors were refined to ensure specificity (e.g., for "Run" buttons) and linting/formatting issues were addressed to meet project standards.